### PR TITLE
Add back requirements for deploying with serverless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Jinja2>=2.10.3
+python-dateutil>=2.8.1
+python-gitlab>=1.8.0
+semver>=2.9.0

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,3 +24,6 @@ functions:
       - http:
           path: gitlab
           method: post
+custom:
+  pythonRequirements:
+    usePoetry: false


### PR DESCRIPTION
Serverless only deploys dependencies using a requirements.txt file so this needed to be re-added. https://www.serverless.com/plugins/serverless-python-requirements/