### PR TITLE
Add instructions for contributing and testing locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,31 @@ Our Julia packages are registered in a private Julia package registry hosted on 
 Each MR registers a new package or a new version of a Julia package.
 Even though we host a private Registrator deployment, this can be used on any GitLab Julia package registry repository independently from where the MRs originate.
 
-## License
+## Changelogs (Release Notes)
 
-tagbotgitlab is provided under an MIT License.
+TagBotGitlab creates a changelog for each release based on the issues that have been closed and the merge requests that have been merged. Unlike [TagBot](https://github.com/JuliaRegistries/TagBot), TagBotGitLab currently does not support custom release notes or customizable templates.
+
+Issues and pull requests with specified labels are not included in the changelog data.
+By default, the following labels are ignored:
+
+- changelog skip
+- duplicate
+- exclude from changelog
+- invalid
+- no changelog
+- question
+- wont fix
+
+White-space, case, dashes, and underscores are ignored when comparing labels.
 
 ## Future Direction
-This package is not uploaded to PyPI for now, but we hope to upload it eventually so that things like the `Changelog` can be used seprately from the automatic merging of GitLab MRs.
+
+This package is not uploaded to PyPI for now, but we hope to upload it eventually so that things like the `Changelog` can be used separately from the automatic merging of GitLab MRs.
 
 The vision is to use only the `Changelog` on our prod repository when manual tags are made to populate the release notes automatically.
 
-
 ## Installation
+
 To install this just install it into a virtualenv like so:
 
 ```
@@ -59,19 +73,16 @@ Steps:
 
 This code is tested on GitLab version `11.11.0-ee`.
 
-### Changelogs (Release Notes)
+## Contributing
 
-TagBotGitlab creates a changelog for each release based on the issues that have been closed and the merge requests that have been merged. Unlike [TagBot](https://github.com/JuliaRegistries/TagBot), TagBotGitLab currently does not support custom release notes or customizable templates.
+This package uses the [python-gitlab](https://python-gitlab.readthedocs.io/en/stable/index.html) package to interact with GitLab and it's useful to refer to their documentation when making changes.
+You can test using their API locally by generating a [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token) and setting it in the `local_test.py` script included.
 
-Issues and pull requests with specified labels are not included in the changelog data.
-By default, the following labels are ignored:
+You can run tests locally by running in the virtualenv you installed the package in:
+```
+tox
+```
 
-- changelog skip
-- duplicate
-- exclude from changelog
-- invalid
-- no changelog
-- question
-- wont fix
+## License
 
-White-space, case, dashes, and underscores are ignored when comparing labels.
+tagbotgitlab is provided under an MIT License.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Even though we host a private Registrator deployment, this can be used on any Gi
 
 ## Changelogs (Release Notes)
 
-TagBotGitlab creates a changelog for each release based on the issues that have been closed and the merge requests that have been merged. Unlike [TagBot](https://github.com/JuliaRegistries/TagBot), TagBotGitLab currently does not support custom release notes or customizable templates.
+TagBotGitLab creates a changelog for each release based on the issues that have been closed and the merge requests that have been merged. Unlike [TagBot](https://github.com/JuliaRegistries/TagBot), TagBotGitLab currently does not support custom release notes or customizable templates.
 
 Issues and pull requests with specified labels are not included in the changelog data.
 By default, the following labels are ignored:
@@ -75,8 +75,9 @@ This code is tested on GitLab version `11.11.0-ee`.
 
 ## Contributing
 
-This package uses the [python-gitlab](https://python-gitlab.readthedocs.io/en/stable/index.html) package to interact with GitLab and it's useful to refer to their documentation when making changes.
-You can test using their API locally by generating a [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token) and setting it in the `local_test.py` script included.
+This package uses the [python-gitlab](https://python-gitlab.readthedocs.io/en/stable/index.html) package to interact with GitLab.
+It's useful to refer to their documentation when making changes.
+You can test using their API locally by generating a [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token) and setting it in the included `local_test.py` script.
 
 You can run tests locally by running in the virtualenv you installed the package in:
 ```

--- a/local_test.py
+++ b/local_test.py
@@ -1,6 +1,6 @@
 # This file is intended for local testing when contributing to this repository
-# Do not committ any changes
-# You will need to generate a Gitlab Personal Access Token to use this
+# Do not commit any changes
+# You will need to generate a GitLab Personal Access Token to use this
 import os
 from os import environ as env
 
@@ -33,5 +33,5 @@ for tag in tags:
     print("\n-----------------------------------------------------------------------\n")
 
     # Note the line below will actually set the release notes in the repository used
-    # Should only be used if that is intended behaviour
+    # Should only be used if that is the intended behaviour
     # tag.set_release_description(release_notes)

--- a/local_test.py
+++ b/local_test.py
@@ -1,0 +1,37 @@
+# This file is intended for local testing when contributing to this repository
+# Do not committ any changes
+# You will need to generate a Gitlab Personal Access Token to use this
+import os
+from os import environ as env
+
+import gitlab
+from tagbotgitlab.changelog import Changelog
+
+
+# Set some environment variables required for import.
+env["GITLAB_URL"] = "https://gitlab.invenia.ca"
+env["GITLAB_API_TOKEN"] = "<the-personal-access-token-you-created>"
+
+
+client = gitlab.Gitlab(
+    os.environ["GITLAB_URL"], private_token=os.environ["GITLAB_API_TOKEN"]
+)
+
+repo = "invenia/TestRepo.jl"
+
+p = client.projects.get(repo, lazy=True)
+changelog = Changelog(p)
+
+
+tags = p.tags.list(all=False)
+for tag in tags:
+    commit = tag.commit["id"]
+    version = tag.name
+
+    release_notes = changelog.get(version, commit)
+    print(release_notes)
+    print("\n-----------------------------------------------------------------------\n")
+
+    # Note the line below will actually set the release notes in the repository used
+    # Should only be used if that is intended behaviour
+    # tag.set_release_description(release_notes)


### PR DESCRIPTION
Link to the rendered README: https://github.com/invenia/TagBotGitLab/blob/ne/add-contributing-instructions/README.md

Some of the changes are just moving sections around