### PR TITLE
Bump min python-gitlab version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-gitlab>=1.8.0
+python-gitlab>=2.7.1
 gitlabchangelog>=0.1.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ TEST_DEPS = ["coverage", "pytest", "pytest-cov"]
 DOCS_DEPS = ["sphinx", "sphinx-rtd-theme", "sphinx-autoapi", "recommonmark"]
 CHECK_DEPS = ["isort", "flake8", "flake8-quotes", "pep8-naming", "mypy", "black"]
 REQUIREMENTS = [
-    "python-gitlab>=1.8.0",
+    "python-gitlab>=2.7.1",
     "gitlabchangelog>=0.1.0",
 ]
 


### PR DESCRIPTION
The bug discovered in https://github.com/python-gitlab/python-gitlab/issues/1425 was using python-gitlab `v2.5.0`. It has been verified in https://github.com/python-gitlab/python-gitlab/pull/1426 that the bug no longer exists in `v2.7.1`.