### PR TITLE
Update functions to match new MR event payload format

### DIFF
--- a/tagbotgitlab/tagbot.py
+++ b/tagbotgitlab/tagbot.py
@@ -59,11 +59,11 @@ def handle_open(payload):
     """Handle a merge request open event."""
     if not merge:
         return "Automatic merging is disabled"
-    if get_in(payload, "changes", "iid", "previous") is not None:
+    if get_in(payload, "changes", "updated_by_id", "previous") is not None:
         return "Not a new MR"
     p_id = get_in(payload, "object_attributes", "source_project_id")
     p = client.projects.get(p_id, lazy=True)
-    mr_id = get_in(payload, "changes", "iid", "current")
+    mr_id = get_in(payload, "object_attributes", "iid")
     mr = p.mergerequests.get(mr_id, lazy=True)
 
     print("Approving MR")

--- a/tests/test_tagbot.py
+++ b/tests/test_tagbot.py
@@ -261,7 +261,10 @@ def test_handle_open(patched_time_sleep):
 
     # when mr is not a newly opened mr
     tagbot.merge = True
-    assert tagbot.handle_open({"changes": {"iid": {"previous": 1}}}) == "Not a new MR"
+    assert (
+        tagbot.handle_open({"changes": {"updated_by_id": {"previous": 1}}})
+        == "Not a new MR"
+    )
 
     # all valid, performs merge
     assert (


### PR DESCRIPTION
## Summary
The [MR event payload format](https://docs.gitlab.com/13.11/ee/user/project/integrations/webhooks.html#merge-request-events) seems to have slightly changed since this was implemented.

## Changes
### Information about changes to MR:
Before
```
 "changes": {
    "iid": {
        "previous": null,
        "current": 1
    }
}
```

New
```
"changes": {
    "updated_by_id": {
         "previous": null,
         "current": 1
    }
}
```

### Where to find the MR's `iid`:
Before
```
 "changes": {
    "iid": {
        "previous": null,
        "current": 1
    }
}
```

New
`iid` is no longer stored in the `changes` Dict 
```
"object_attributes": {
    "iid": 1234,
}
```
