### PR TITLE
Poll for merge_status before accepting merge request

### DIFF
--- a/tagbotgitlab/tagbot.py
+++ b/tagbotgitlab/tagbot.py
@@ -8,6 +8,8 @@ import gitlab  # type: ignore
 from gitlabchangelog.changelog import Changelog  # type: ignore
 
 
+POLL_TIMEOUT = 1
+
 # match on group3 to get everything after the host, i.e everything after the single '/'
 re_repo = re.compile("Repository:\\s*(http[s]?://)?([^/\\s]+/)(.*)")
 re_version = re.compile("Version:\\s*(v.*)")
@@ -89,6 +91,8 @@ def handle_open(payload):
     # See https://gitlab.com/gitlab-org/gitlab/-/issues/196962
     while mr.merge_status == "checking":
         print(f"Polling for merge_status: {mr.merge_status}")
+        # Avoid slamming the API
+        time.sleep(POLL_TIMEOUT)
         mr = p.mergerequests.get(mr_id, lazy=False)
 
     print(f"Merging MR {mr}")

--- a/tagbotgitlab/tagbot.py
+++ b/tagbotgitlab/tagbot.py
@@ -83,6 +83,14 @@ def handle_open(payload):
         timeout += 1
         mr = p.mergerequests.get(mr_id, lazy=False)
 
+    # Accepting the MR while the merge_status is "checking" seems to result in a
+    # 406 error.
+    # To work around this, poll until the merge_status is no longer "checking".
+    # See https://gitlab.com/gitlab-org/gitlab/-/issues/196962
+    while mr.merge_status == "checking":
+        print(f"Polling for merge_status: {mr.merge_status}")
+        mr = p.mergerequests.get(mr_id, lazy=False)
+
     print(f"Merging MR {mr}")
     mr.merge(merge_when_pipeline_succeeds=True, should_remove_source_branch=True)
     return "Approved and merged."

--- a/tests/test_tagbot.py
+++ b/tests/test_tagbot.py
@@ -250,6 +250,7 @@ def test_handle_merge():
 def test_handle_open(patched_time_sleep):
     mr = Mock(spec=gitlab.v4.objects.ProjectMergeRequest)
     mr.head_pipeline = {"id": 62299}
+    mr.merge_status = "can_be_merged"
     p = Mock(spec=gitlab.v4.objects.Project)
     p.mergerequests = Mock(spec=gitlab.v4.objects.ProjectMergeRequestManager)
     p.mergerequests.get = Mock(return_value=mr)
@@ -285,6 +286,7 @@ def test_handle_open(patched_time_sleep):
     # the merge is not valid but this is mocked so it succeeds fine
     mr = Mock(spec=gitlab.v4.objects.ProjectMergeRequest)
     mr.head_pipeline = None
+    mr.merge_status = "can_be_merged"
     p = Mock(spec=gitlab.v4.objects.Project)
     p.mergerequests = Mock(spec=gitlab.v4.objects.ProjectMergeRequestManager)
     p.mergerequests.get = Mock(return_value=mr)


### PR DESCRIPTION
# Problem
After an MR is approved (`mr.approve`), the `merge_status` might still be `checking` when accepting the MR (`mr.merge`) which can result in a 406 error. This seems to be a timing issue that others are experiencing here: https://gitlab.com/gitlab-org/gitlab/-/issues/196962. 

# Fix
A workaround suggested in the issue above is to poll the MR until the `merge_status` is no longer `checking` (i.e. `cannot_be_merged` or `can_be_merged`) before accepting it.