### PR TITLE
Stop at '<' when parsing the MR body to support LocalRegistry.jl

### DIFF
--- a/tagbotgitlab/tagbot.py
+++ b/tagbotgitlab/tagbot.py
@@ -145,7 +145,8 @@ def parse_body(body):
     m = re_repo.search(body)
     if not m:
         return None, None, None, "No repo match"
-    # match on group3 to get everything after the host, i.e everything after the single '/'
+    # match on group3 to get everything after the host, i.e everything after
+    # the first single '/'
     repo = m[3].strip()
     m = re_version.search(body)
     if not m:

--- a/tests/test_tagbot.py
+++ b/tests/test_tagbot.py
@@ -27,6 +27,7 @@ good_body_with_html = (
     "• Triggered by: @john.doe<br>"
 )
 
+
 def test_parse_body():
     repo, version, commit, err = tagbot.parse_body(good_body)
     assert repo == "foo/bar"


### PR DESCRIPTION
Implements #35 

Opted for a simple fix where we stop matching fields at `<` as these represent the start of potential HTML tags. This should be ok given`<` is not a valid character in URLs, commit SHA-1 hashes, or semver versions.

Alternatives could be:
1. Parse as HTML and remove all HTML tags before processing the text (more complex)
2. Stricter regexes for each field: a URL regex, semver version regex, commit SHA-1 regex (more complex + unnecessarily strict)

